### PR TITLE
set `config` prop to be optional in typescript Props definition

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -52,7 +52,7 @@ declare module "particles-bg" {
     num?: number;
     bg?: boolean;
     color?: string;
-    config: ConfigProp;
+    config?: ConfigProp;
   }
 
   class ParticlesBg extends React.Component<Props, any> {}


### PR DESCRIPTION
For https://github.com/lindelof/particles-bg/issues/5